### PR TITLE
Use isdefined instead of VERSION check for test_warn

### DIFF
--- a/test/test_Diversity.jl
+++ b/test/test_Diversity.jl
@@ -1,6 +1,6 @@
 module TestDiversity
 using Base.Test
-if VERSION <= v"0.6.0-pre.beta"
+if !isdefined(Base.Test, Symbol("@test_warn"))
     # Ignore @test_warn unless it's there...
     macro test_warn(str, test)
     end

--- a/test/test_EffectiveNumbers.jl
+++ b/test/test_EffectiveNumbers.jl
@@ -1,6 +1,6 @@
 module TestEffectiveNumbers
 using Base.Test
-if VERSION <= v"0.6.0-pre.beta"
+if !isdefined(Base.Test, Symbol("@test_warn"))
     # Ignore @test_warn unless it's there...
     macro test_warn(str, test)
     end

--- a/test/test_Metacommunity.jl
+++ b/test/test_Metacommunity.jl
@@ -1,6 +1,6 @@
 module TestMetacommunity
 using Base.Test
-if VERSION <= v"0.6.0-pre.beta"
+if !isdefined(Base.Test, Symbol("@test_warn"))
     # Ignore @test_warn unless it's there...
     macro test_warn(str, test)
     end


### PR DESCRIPTION
more precise, would avoid overwriting it on the range of 0.6 versions where it was defined